### PR TITLE
Add support for eviction-allowed annotation and flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ helm repo update
 helm install soft-pod-memory-evicter maxlaverse/soft-pod-memory-evicter
 ```
 
+## Annotations
+
+The controller will respect the following annotation to decide whether to evict a Pod or not:
+
+```yaml
+soft-pod-memory-evicter/eviction-allowed: "true"
+```
+
 ## Usage
 
 ```
@@ -34,6 +42,7 @@ COMMANDS:
 
 GLOBAL OPTIONS:
    --dry-run                            Output additional debug lines (default: false)
+   --strict-annotation                  Only evict Pods with the annotation 'soft-pod-memory-evicter/eviction-allowed' set to 'true' (default: false)
    --eviction-pause value               Pause duration between evictions (default: 5m0s)
    --memory-usage-check-interval value  Interval at which the Pod metrics are checked (default: 3m0s)
    --memory-usage-threshold value       Memory usage eviction threshold (0-100) (default: 95)

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 func main() {
 	opts := pkg.Options{
 		DryRun:                   false,
+		IsAnnotationRequired:     false,
 		EvictionPause:            time.Duration(5) * time.Minute,
 		MemoryUsageCheckInterval: time.Duration(3) * time.Minute,
 		MemoryUsageThreshold:     95,
@@ -36,6 +37,11 @@ func main() {
 				Usage:       "Output additional debug lines",
 				Value:       opts.DryRun,
 				Destination: &opts.DryRun,
+			}, &cli.BoolFlag{
+				Name:        "strict-annotation",
+				Usage:       "Only evict Pods with the annotation 'soft-pod-memory-evicter/eviction-allowed' set to 'true'",
+				Value:       opts.IsAnnotationRequired,
+				Destination: &opts.IsAnnotationRequired,
 			}, &cli.DurationFlag{
 				Name:        "eviction-pause",
 				Usage:       "Pause duration between evictions",

--- a/pkg/controller_test.go
+++ b/pkg/controller_test.go
@@ -135,7 +135,7 @@ var (
 		},
 		metrics: metricsv1beta1.PodMetrics{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-pod-3",
+				Name:      "test-pod-4",
 				Namespace: "test-namespace",
 			},
 			Containers: []metricsv1beta1.ContainerMetrics{
@@ -236,7 +236,7 @@ func TestEvictionOnlyAffectsPodsMaxingoutMemory(t *testing.T) {
 	assert.Equal(t, "/v1, Resource=pods", action5.GetResource().String())
 
 	obj3 := action5.(clientgo_testing.CreateAction).GetObject()
-	assert.Equal(t, "test-pod-3", obj3.(*policyv1.Eviction).Name)
+	assert.Equal(t, "test-pod-4", obj3.(*policyv1.Eviction).Name)
 	assert.Equal(t, "test-namespace", obj3.(*policyv1.Eviction).Namespace)
 	assert.Nil(t, obj3.(*policyv1.Eviction).DeleteOptions)
 }


### PR DESCRIPTION
This pull request introduces the ability to respect the eviction-allowed annotation and flag when deciding whether to evict a Pod.